### PR TITLE
Combine options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,13 @@ module.exports = function (config) {
     },
     rollupPreprocessor: {
       // rollup settings. See Rollup documentation
-      rollup: {
-        plugins: [
-          multiEntry(), // Allows specifying multiple entry points with rollup.
-          buble() // ES2015 compiler by the same author as Rollup
-            ]
-          })
-        ]
-      },
-      bundle: {
-        sourceMap: 'inline'
-      }
+      plugins: [
+        multiEntry(), // Allows specifying multiple entry points with rollup.
+        buble() // ES2015 compiler by the same author as Rollup
+          ]
+        })
+      ],
+      sourceMap: 'inline'
     }
   });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,19 +14,16 @@ const touchParents = debounce(() => {
     changedParents.clear();
 }, WAIT);
 
-function createRollupPreprocessor (args, config = {}, logger, helper) {
-
-    let rollupConfig = config.rollup || {};
-    let bundleConfig = config.bundle || {};
+function createRollupPreprocessor (args, options = {}, logger, helper) {
     let log = logger.create('preprocessor.rollup');
 
     return (content, file, done) => {
         log.debug('Processing "%s".', file.originalPath);
 
         try {
-            rollupConfig.entry = file.originalPath;
+            options.entry = file.originalPath;
 
-            rollup(rollupConfig)
+            rollup(options)
                 .then(bundle => {
 
                     // Map this file to the dependencies that Rollup just
@@ -52,9 +49,9 @@ function createRollupPreprocessor (args, config = {}, logger, helper) {
                         }
                     }
 
-                    let { code, map } = bundle.generate(bundleConfig);
+                    let { code, map } = bundle.generate(options);
 
-                    if (bundleConfig.sourceMap === 'inline') {
+                    if (options.sourceMap === 'inline') {
                         code += '\n//# ' + SOURCEMAPPING_URL + '=' + map.toUrl();
                     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,12 +43,10 @@ function runServer (file, options = {}) {
         preprocessors: {
             'fixtures/**': ['rollup']
         },
-        rollupPlugin: {
-            rollup: {
-                plugins: [
-                    buble()
-                ]
-            }
+        rollupPreprocessor: {
+            plugins: [
+                buble()
+            ]
         },
         autoWatch: false,
         singleRun: true
@@ -62,16 +60,13 @@ function runFixture (fixture, options = {}) {
             error: () => {}
         })
     };
-    const config = {
-        rollup: assign({
-            plugins: [
-                buble()
-            ]
-        }, options.rollup),
-        bundle: assign({}, options.bundle)
+    const defaults = {
+        plugins: [
+            buble()
+        ]
     };
     const createPreprocessor = rollupPlugin['preprocessor:rollup'][1];
-    const preprocessor = createPreprocessor(null, config, loggerMock);
+    const preprocessor = createPreprocessor(null, assign(defaults, options), loggerMock);
     const file = {
         originalPath: path.resolve(__dirname, 'fixtures/' + fixture)
     };
@@ -118,9 +113,7 @@ describe('karma-rollup-plugin', () => {
     }));
 
     it('should add inline source map', () => runFixture('es2015.js', {
-        bundle: {
-            sourceMap: 'inline'
-        }
+        sourceMap: 'inline'
     }).then(code => {
         expect(code).to.contain('//# sourceMappingURL');
     }));


### PR DESCRIPTION
In the same way works `rollup.config.js`. We don't need to separate with `rollup` and `bundle` options. It's necessary only for js api.
