### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,3 @@ module.exports = function (config) {
 ```
 
 See [Rollup documentation - JavaScript API](https://github.com/rollup/rollup/wiki/JavaScript-API) for more details.
-
-# Why this plugin?
-
-There exist a `karma-rollup-preprocessor` plugin for `Karma`, but it contains too many bugs, and doesn't seem to be maintained atm. 
-This plugin try to stay true to the `Rollup ecosystem`.


### PR DESCRIPTION
I have adopted Rollup as the module bundler of choice for one of my carefully maintained libraries, and I will be extending the same meticulous care to `karma-rollup-preprocessor` as its new maintainer.

>"There exist a `karma-rollup-preprocessor` plugin for Karma, but it contains too many bugs, and doesn't seem to be maintained atm."

I would appreciate this incorrect section being removed (or at least respectfully updated).
