### PR TITLE
bundle.generate returns a promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,8 @@ function createRollupPreprocessor (args, options = {}, logger) {
         try {
             options.entry = file.originalPath;
 
-            rollup(options).then(bundle => {
-                let { code, map } = bundle.generate(options);
+            rollup(options).then(async bundle => {
+                let { code, map } = await bundle.generate(options);
 
                 if (options.sourceMap === 'inline') {
                     code += '\n//# ' + SOURCEMAPPING_URL + '=' + map.toUrl();


### PR DESCRIPTION
Not really sure you should merge this as I didn't test if this _really_ fixes things. Making this change in the installed version in my project did seem to eliminate the error:

```
ERROR [preprocessor.rollup]: bundle.generate(...) now returns a Promise instead of a { code, map } object
```
Also, the plugin seems to no longer be maintained. Do you know of any alternatives?

Cheers!